### PR TITLE
fix null pointer dereference (segfault) when Cookie header is empty

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -731,7 +731,10 @@ char *getCASCookie(request_rec *r, char *cookieName)
 		/* tokenize on ; to find the cookie we want */
 		cookie = apr_strtok(cookies, ";", &tokenizerCtx);
 		do {
-			while (cookie != NULL && *cookie == ' ')
+			/* no more parameters */
+			if(cookie == NULL)
+				break;
+			while (*cookie == ' ')
 				cookie++;
 			if(strncmp(cookie, cookieName, strlen(cookieName)) == 0) {
 				cookieFound = TRUE;
@@ -740,9 +743,6 @@ char *getCASCookie(request_rec *r, char *cookieName)
 				rv = apr_pstrdup(r->pool, cookie);
 			}
 			cookie = apr_strtok(NULL, ";", &tokenizerCtx);
-		/* no more parameters */
-		if(cookie == NULL)
-			break;
 		} while (cookieFound == FALSE);
 	}
 

--- a/tests/mod_auth_cas_test.c
+++ b/tests/mod_auth_cas_test.c
@@ -551,6 +551,18 @@ START_TEST(setCASCookieExpiryFiveSeconds_test) {
 }
 END_TEST
 
+START_TEST(getCASCookie_empty_test) {
+  const char *expected = "";
+  cas_dir_cfg *d = ap_get_module_config(request->per_dir_config,
+                                        &auth_cas_module);
+  /*
+   * setup request with empty cookie header
+   */
+  apr_table_set(request->headers_in, "Cookie", "");
+  fail_unless(getCASCookie(request, d->CASCookie) == NULL);
+}
+END_TEST
+
 START_TEST(removeGatewayCookie_test) {
   const char *expected = "MOD_CAS_G=TRUE;Secure;Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
   const char *ernVal;
@@ -1361,6 +1373,7 @@ Suite *mod_auth_cas_suite(void) {
   tcase_add_test(tc_core, setCASCookie_test);
   tcase_add_test(tc_core, setCASCookieExpiryNow_test);
   tcase_add_test(tc_core, setCASCookieExpiryFiveSeconds_test);
+  tcase_add_test(tc_core, getCASCookie_empty_test);
   tcase_add_test(tc_core, removeGatewayCookie_test);
   tcase_add_test(tc_core, urlEncode_test);
   tcase_add_test(tc_core, readCASCacheFile_test);


### PR DESCRIPTION
Some days we get hundreds of Apache segmentation faults -- other times weeks go by without one.  It turns out that getCASCookie croaks if a client sends an empty Cookie: header.  This patch fixes the problem.  I added a test too.
