### PR TITLE
Fixed redirect loop with CASTimeout=0

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1674,7 +1674,9 @@ apr_byte_t isValidCASCookie(request_rec *r, cas_cfg *c, char *cookie, char **use
 		return FALSE;
 	}
 
-	if(cache.issued < (apr_time_now()-(c->CASTimeout*((apr_time_t) APR_USEC_PER_SEC))) || cache.lastactive < (apr_time_now()-(c->CASIdleTimeout*((apr_time_t) APR_USEC_PER_SEC)))) {
+    if((c->CASTimeout > 0 &&
+       (cache.issued < (apr_time_now()-(c->CASTimeout*((apr_time_t) APR_USEC_PER_SEC))))) ||
+       cache.lastactive < (apr_time_now()-(c->CASIdleTimeout*((apr_time_t) APR_USEC_PER_SEC)))) {
 		/* delete this file since it is no longer valid */
 		deleteCASCacheFile(r, cookie);
 		if(c->CASDebug)


### PR DESCRIPTION
Setting the CASTimeout option to 0 should allow a non-idle session to not expire. Instead, it initiated an endless redirect loop to the CAS server and back. This happened because the CAS cache file was instantly deleted upon being created. This commit prevents the cache from being deleted when CASTimeout is set to 0.