### PR TITLE
Use ap_hook_check_authn() instead of ap_hook_check_access().

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -2343,6 +2343,8 @@ authz_status cas_check_authorization(request_rec *r,
 		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r,
 			      "Entering cas_check_authorization.");
 
+	if(!r->user) return AUTHZ_DENIED_NO_USER;
+
 	t = require_line;
 	while ((w = ap_getword_conf(r->pool, &t)) && w[0]) {
 		count_casattr++;
@@ -2753,7 +2755,7 @@ void cas_register_hooks(apr_pool_t *p)
 #endif
 
 #if MODULE_MAGIC_NUMBER_MAJOR >= 20120211
-	ap_hook_check_access(
+	ap_hook_check_authn(
 		cas_authenticate,
 		NULL,
 		NULL,

--- a/tests/ap_stubs.c
+++ b/tests/ap_stubs.c
@@ -230,6 +230,12 @@ AP_DECLARE(void) ap_hook_check_access(ap_HOOK_access_checker_t *pf,
                                       int nOrder, int type) {
 }
 
+AP_DECLARE(void) ap_hook_check_authn(ap_HOOK_access_checker_t *pf,
+                                     const char * const *aszPre,
+                                     const char * const *aszSucc,
+                                     int nOrder, int type) {
+}
+
 AP_DECLARE(apr_status_t) ap_register_auth_provider(apr_pool_t *pool,
                                                    const char *provider_group,
                                                    const char *provider_name,


### PR DESCRIPTION
Fixes #93.

This allows "Satisy Any" and the 2.4-style multiple Require(Any|All)
lines to work properly.

The Apache 2.4 docs say the following about ap_hook_check_authn():

This hook is used to analyze the request headers, authenticate the user,
and set the user information in the request record (r->user and
r->ap_auth_type). This hook is only run when Apache determines that
authentication/authorization is required for this resource (as
determined by the 'Require' directive). It runs after the access_checker
hook, and before the auth_checker hook. This hook should be registered
with ap_hook_check_authn(). If "Satisfy any" is in effect, this hook may
be skipped.

AUTHZ_DENIED_NO_USER needs to be returned in cas_check_authorization()
in case the user hasn't been authenticated yet.

Add stub for ap_hook_check_authn().