### PR TITLE
Add Google Group link to README

### DIFF
--- a/README
+++ b/README
@@ -390,4 +390,8 @@ and bug reports.  To reach the development team, send an e-mail to:
 
 cas-user [at] apereo [dot] org
 
+Google Group link:
+
+https://groups.google.com/a/apereo.org/forum/#!forum/cas-user
+
 ========================================================================


### PR DESCRIPTION
Users must join cas-user before being able to post. Add a direct link to the README.

Addresses issue #100.