### PR TITLE
CASv2 attributes may need to be scrubbed now.

### DIFF
--- a/src/mod_auth_cas.c
+++ b/src/mod_auth_cas.c
@@ -1999,7 +1999,7 @@ void cas_scrub_request_headers(
 	r->headers_in =
 		cas_scrub_headers(
 			r->pool,
-			c->CASValidateSAML ? c->CASAttributePrefix : NULL,
+			c->CASAttributePrefix,
 			d->CASAuthNHeader,
 			r->headers_in,
 			&dirty_headers);


### PR DESCRIPTION
Since CASv2 attributes can now be used, we should make sure that headers are properly scrubbed.

I think this is the right thing to do in this place, but I'd like someone else to verify.